### PR TITLE
Mudança do atributo BirthDate para Birthdate na classe Portador

### DIFF
--- a/Moip.Net/V2/Model/Portador.cs
+++ b/Moip.Net/V2/Model/Portador.cs
@@ -5,7 +5,7 @@ namespace Moip.Net.V2.Model
     public class Portador
     {
         public string Fullname { get; set; }
-        public string BirthDate { get; set; }
+        public string Birthdate { get; set; }
         public Telefone Phone { get; set; }
         public Documento TaxDocument { get; set; }
         public Endereco BillingAddress { get; set; }

--- a/Moip.NetTests/V2/V2ClientTests.cs
+++ b/Moip.NetTests/V2/V2ClientTests.cs
@@ -139,7 +139,7 @@ namespace Moip.Net.V2.Tests
                     Holder = new Portador()
                     {
                         Fullname = "Jose Portador da Silva",
-                        BirthDate = DateTime.Now.ToString("yyyy-MM-dd"),
+                        Birthdate = DateTime.Now.ToString("yyyy-MM-dd"),
                         TaxDocument = new Documento()
                         {
                             Type = DocumentType.CPF,
@@ -252,7 +252,7 @@ namespace Moip.Net.V2.Tests
                         Holder = new Portador()
                         {
                             Fullname = "Jose Portador da Silva",
-                            BirthDate = "1988-12-30",
+                            Birthdate = "1988-12-30",
                             TaxDocument = new Documento()
                             {
                                 Type = DocumentType.CPF,


### PR DESCRIPTION
Aparentemente o problema que estava ocorrendo está relacionado ao atributo BirthDate da classe `Portador`.  Fiz alguns testes via postman e utilizei o atributo da mesma forma está implementado atualmente e obtive o mesmo erro. Executei os testes e não houve problema.